### PR TITLE
1주차 기본과제 #1

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -3,10 +3,17 @@ package io.hhplus.tdd.point;
 import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PointService {
@@ -14,7 +21,10 @@ public class PointService {
     private final UserPointTable userPointTable;
     private final PointHistoryTable pointHistoryTable;
 
-     // 특정 유저의 포인트 조회
+    // 유저별 락 관리용 Map
+    private final ConcurrentHashMap<Long, Lock> locks = new ConcurrentHashMap<>();
+
+    // 특정 유저의 포인트 조회
     public UserPoint selectPoint(long id) {
         return userPointTable.selectById(id);
     }
@@ -26,11 +36,46 @@ public class PointService {
 
     // 특정 유저의 포인트 충전
     public UserPoint insertPoint(long id, long amount){
-        return userPointTable.insertOrUpdate(id, amount);
+        Lock lock = locks.computeIfAbsent(id, k -> new ReentrantLock(true));
+        boolean locked = false;
+
+        try {
+            // 락을 시도하고, 3초 이내에 락을 얻지 못하면 예외 발생
+            locked = lock.tryLock(3, TimeUnit.SECONDS);
+
+            if(!locked) {
+                throw new IllegalStateException("요청이 지연되어 처리에 실패했습니다. 다시 시도해주세요.");
+            }
+
+            return userPointTable.insertOrUpdate(id, amount);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("포인트 충전 처리 중 문제가 발생했습니다.");
+        } finally {
+            if(locked) {
+                lock.unlock();
+            }
+        }
     }
 
     // 특정 유저의 포인트 사용
     public UserPoint updatePoint(long id, long amount){
-        return userPointTable.insertOrUpdate(id, amount);
+        Lock lock = locks.computeIfAbsent(id, k -> new ReentrantLock(true));
+        boolean locked = false;
+
+        try {
+            locked = lock.tryLock(3, TimeUnit.SECONDS);
+
+            if(!locked) {
+                throw new IllegalStateException("요청이 지연되어 처리에 실패했습니다. 다시 시도해주세요.");
+            }
+
+            return userPointTable.insertOrUpdate(id, amount);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("포인트 입력 처리 중 문제가 발생했습니다.");
+        }finally {
+            if(locked) {
+                lock.unlock();
+            }
+        }
     }
 }


### PR DESCRIPTION
## 동시성 제어를 위한 포인트 충전/사용 기능 및 테스트

포인트 충전 및 사용 기능을 개선하고, 다중 스레드 환경에서의 안정성을 검증하기 위한 동시성 테스트 코드 작성

### 요구사항

1. **API 요청**
    - `PATCH /point/{id}/charge`: 포인트를 충전합니다.
    - `PATCH /point/{id}/use`: 포인트를 사용합니다.
    - `GET /point/{id}`: 현재 포인트를 조회합니다.
    - `GET /point/{id}/histories`: 포인트 내역을 조회합니다.
2. **비즈니스 로직**
    - 잔고가 부족할 경우, 포인트 사용은 실패해야 합니다.
    - 동시에 여러 건의 포인트 충전/사용 요청이 들어오면 순차적으로 처리되어야 합니다.

### 요구사항 분석 및 정책

1. **포인트 작업의 동시성 조건**
    - **다중 유저**: 서로 다른 유저는 포인트 사용/충전/조회 작업을 병렬로 실행할 수 있습니다.
    - **단일 유저**: 동일한 유저에 대한 사용/충전/조회 작업은 순차적으로 실행되어야 합니다.
2. **포인트 한도 및 조건**
    - **최소/최대 보유 포인트**: 0원 ~ 1,000,000원
    - **최소/최대 충전 포인트**: 1,000원 ~ 100,000원
        - 보유 포인트가 1,000,000원을 초과하면 충전할 수 없습니다.
    - **최소/최대 사용 포인트**: 1,000원 ~ 500,000원
        - 보유 포인트가 사용하려는 포인트보다 적으면 사용할 수 없습니다.
3. **에러 및 예외 처리**
    - 포인트 충전/사용 시 시스템 에러가 발생하면 작업이 중단됩니다.
    - 작업 요청이 3초 이내에 처리되지 않을 경우, `Exception`을 발생시켜 요청을 실패 처리합니다.
        - 지연시간 설정 기준 : 평균 처리 시간의 2-3배를 기본값으로 설정
        - 포인트 충전/사용 요청이 평균 1초 소요된다고 가정

---

## 커밋 링크

- 서비스 기능 추가 : 
- 포인트 충전 및 사용 단위 테스트 추가 :
- 동시성 제어 통합 테스트 추가 :

---

## 리뷰 포인트 (질문)

1. **동시성 제어 방식**
    - `ReentrantLock(true)`의 공정성 문제를 해결할 수 있는 설계 방안이 있을까요?
    - 병렬 처리 환경에서 락 관리(EX: 해시 기반, 분산 락)를 효율적으로 구현할 수 있는 사례나 참고 자료를 공유 부탁드립니다.
2. **동시성 테스트 실패 케이스**
    - 동일 유저의 포인트 사용/조회 동시 요청 시, `Race Condition`으로 두 번의 포인트 사용이 성공하는 문제가 발생했습니다.
        - `selectPoint`와 `updatePoint` 간의 동기화를 개선할 방안이 있을까요?
        - 실패 케이스를 남겨두기보다 해결 방안을 설계하는 것이 적절한지 의견 부탁드립니다.
3. 추가적인 피드백
    - 동시성 처리 테스트에서 정상 데이터 검증만으로 충분한지, 예외 상황을 포함해야 하는지 의견 부탁드립니다.
    - 실무적인 경험이나 참고 자료가 있다면 추천 부탁드립니다.

---

## 이번주 KPT 회고

### Keep

- 일정 관리 : 일요일 ~ 목요일까지 시간을 효율적으로 분배하며 과제를 진행
- 도메인 지식 : E-Commerce 실무 경험을 바탕으로 포인트 정책(조회/충전/사용) 분석을 원활이 진행

### Problem

- 테스트 설계의 어려움
    - 단위 및 통합 테스트의 작성 기준을 수립하는 데 어려움을 겪음
    - `@Mock` 데이터를 활용하는데 익숙하지 않음
- 동시성 제어
    - `*ReentrantLock(true)*` 사용 시 공정성 보장 문제 발생 > 여러 스레드가 락을 획득 하려고 할 때, 실행 순서를 예측 할 수 없어 기대 했던 값을 얻지 못함 EX) `단일_유저의_충전_요청_처리`
    - 동시성 테스트에서 발생하는 Exception 상황까지 검증하는 방법에 대해 고민
- 검증 데이터 설정
    - 동시성 처리 검증을 위해 예상 값을 설정하는 기준에 대한 고민

### Try

- 테스트 설계 개선
    - 단위 테스트 : 단위로 초점을 맞춰 테스트 시나리오 작성
    - 시나리오 기반으로 정책별 예상 결과와 입력값을 정의하여 혼란을 줄임
- 공정성 보장 문제 해결 시도
    - `*ReentrantLock(true)*`의 공정성 문제를 분석하며 추가적인 방안 모색:
    
    ```jsx
    private final ConcurrentHashMap<Long, Lock> locks = new ConcurrentHashMap<>();
    Lock lock = locks.computeIfAbsent(id, k -> new ReentrantLock(true));
    ```
    
    - `lock.tryLock()` 매서드를 활용하여 락을 기다리는 동안 다른 스레득 작업을 선점할 수 있도록 구현
    - 하지만, 공정성 보장이 기대한 순서대로 이루어지지 않아 추가적인 구조 설계 필요성 인지
    - 해시 기반 락 관리 방식의 한계를 확인하고, 병렬 작업 환경에서의 대한(예 : 분산 락) 탐색 중
- Exceptio 검증 기준 설정
    - 동시성 처리 검증 목표를 정상 데이터 처리 여부로 제한하여 정책적으로 유료한 시나리오만 테스트
    - 예상되지 않은 예외 발생 케이스 정책 사항은 탐색 중